### PR TITLE
Throw on max header length true by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const MAX_HEADER_LENGTH = 2000
-const THROW_ON_MAX_HEADER_LENGTH_EXCEEDED = false
+const THROW_ON_MAX_HEADER_LENGTH_EXCEEDED = true
 
 function hasRel (x) {
   return x && x.rel


### PR DESCRIPTION
This is to prevent silent issues downstream, has to be explicitly turned off now.